### PR TITLE
Fix urls to be relative

### DIFF
--- a/govuk_tech_docs.gemspec
+++ b/govuk_tech_docs.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
 
 
-  spec.add_development_dependency "bundler", "~> 2.0.1"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "capybara", "~> 2.18.0"
   spec.add_development_dependency "rubocop-govuk", "~> 1.0.0"

--- a/lib/assets/javascripts/_modules/collapsible-navigation.js
+++ b/lib/assets/javascripts/_modules/collapsible-navigation.js
@@ -60,10 +60,16 @@
     function openActiveHeading () {
       var $activeElement
       var currentPath = window.location.pathname
+
+      // Make paths relative for built version of docs
+      if (currentPath.indexOf('/docs/') !== -1) {
+        currentPath = Util.resolvePathForBuild(currentPath);
+      }
+
       var isActiveTrail = '[href*="' + currentPath + '"]'
       // Add an exception for the root page, as every href includes /
       if (currentPath === '/') {
-        isActiveTrail = '[href="' + currentPath + window.location.hash + '"]'
+        isActiveTrail = '[href=".' + currentPath + window.location.hash + '"]'
       }
       for (var i = $topLevelItems.length - 1; i >= 0; i--) {
         var $element = $($topLevelItems[i])

--- a/lib/assets/javascripts/_modules/in-page-navigation.js
+++ b/lib/assets/javascripts/_modules/in-page-navigation.js
@@ -72,17 +72,24 @@
     function highlightActiveItemInToc (fragment) {
       // Navigation items for single page navigation don't necessarily include the path name, but
       // navigation items for multipage navigation items do include it. This checks for either case.
+      var currentPath = window.location.pathname
+
+      // Make paths relative for built version of docs
+      if (currentPath.indexOf("/docs/") !== -1) {
+        currentPath = Util.resolvePathForBuild(currentPath);
+      }
+
       var $activeTocItem = $tocItems.filter(
-        '[href="' + window.location.pathname + fragment + '"],[href="' + fragment + '"]'
+        '[href=".' + currentPath + fragment + '"],[href="' + fragment + '"]'
       )
       // Navigation items with children don't contain fragments in their url
       // Check to see if any nav items contain just the path name.
       if (!$activeTocItem.get(0)) {
-        $activeTocItem = $tocItems.filter('[href="' + window.location.pathname + '"]')
+        $activeTocItem = $tocItems.filter('[href="' + currentPath + '"]')
       }
       if ($activeTocItem.get(0)) {
-        $tocItems.removeClass('toc-link--in-view')
-        $activeTocItem.addClass('toc-link--in-view')
+        $tocItems.removeClass("toc-link--in-view")
+        $activeTocItem.addClass("toc-link--in-view")
         scrollTocToActiveItem($activeTocItem)
       }
     }

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -34,7 +34,7 @@
     this.downloadSearchIndex = function downloadSearchIndex () {
       updateTitle('Loading search index')
       $.ajax({
-        url: '/search.json',
+        url: './search.json',
         cache: true,
         method: 'GET',
         success: function (data) {

--- a/lib/assets/javascripts/_modules/utilities.js
+++ b/lib/assets/javascripts/_modules/utilities.js
@@ -1,0 +1,15 @@
+(function () {
+  "use strict";
+  function Util () {} 
+
+  Util.resolvePathForBuild = function (path) {
+    if (path.indexOf("/docs/") !== -1) {
+      var currentPath = path.slice(path.lastIndexOf("/"))
+      currentPath = currentPath === "/index.html" ? "/" : currentPath
+
+      return currentPath
+    }
+  }
+
+  window.Util = Util
+})();

--- a/lib/assets/javascripts/_start-modules.js
+++ b/lib/assets/javascripts/_start-modules.js
@@ -1,4 +1,5 @@
 //= require _govuk/modules
+//= require _modules/utilities
 //= require _modules/anchored-headings
 //= require _modules/in-page-navigation
 //= require _modules/navigation

--- a/lib/govuk_tech_docs/table_of_contents/helpers.rb
+++ b/lib/govuk_tech_docs/table_of_contents/helpers.rb
@@ -70,7 +70,7 @@ module GovukTechDocs
             output +=
               single_page_table_of_contents(
                 content,
-                url: resource.url,
+                url: ".#{resource.url}",
                 max_level: config[:tech_docs][:max_toc_heading_level],
               )
           end


### PR DESCRIPTION
`*.api.publish-teacher-training-courses.service.gov.uk` needs to redirect to `/docs` as the root domain (`*.publish-teacher-training-courses.service.gov.uk`) will now serve the Rails app.

In order to do this, we have to fix some the urls and make them relative.

Supporting PR: https://github.com/DFE-Digital/teacher-training-api/pull/2433